### PR TITLE
refactor app service name on CLI.

### DIFF
--- a/.github/workflows/open-ai-app.yml
+++ b/.github/workflows/open-ai-app.yml
@@ -93,7 +93,7 @@ jobs:
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ secrets.AZURE_APP_SERVICE_NAME }}
+          app-name: azure-chat-demo-webapp-f2zdrafh3uvys
           package: ${{ github.workspace }}/Nextjs-site.zip
 
       - name: 🧹 Cleanup


### PR DESCRIPTION
Apparently ${{ secrets.App_SERVICE_NAME }} does not work and we gotta use the actual name. We copy paste the actual name here.